### PR TITLE
Potential fix for code scanning alert no. 1: Application backup allowed

### DIFF
--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     package="com.rd.pageindicatorview.sample">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"


### PR DESCRIPTION
Potential fix for [https://github.com/SPHTech/AndroidPageIndicatorView/security/code-scanning/1](https://github.com/SPHTech/AndroidPageIndicatorView/security/code-scanning/1)

Set `android:allowBackup` to `false` in `sample/src/main/AndroidManifest.xml` on the `<application>` element. This is the minimal and best fix: it removes automatic backup exposure without changing runtime app functionality (activities, intents, theme, etc.). No imports, methods, or additional definitions are needed—just update the existing manifest attribute value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
